### PR TITLE
Fix/add pywer dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,5 @@ pandas>=1.3.0
 opencc-python-reimplemented>=0.1.7
 flask-socketio>=5.3.0
 webrtcvad>=2.0.10
-websockets>=11.0.0 
+websockets>=11.0.0
+pywer>=0.1.1


### PR DESCRIPTION
Add missing `pywer` dependency to `requirements.txt`

## Problem
Running `asr_core.py` fails with `ModuleNotFoundError: No module named 'pywer'`

<img width="1378" height="149" alt="image" src="https://github.com/user-attachments/assets/baeda8f4-d081-46b7-ade0-6e1b76b3f8ae" />

## Solution
Added `pywer` to the project dependencies.